### PR TITLE
Improvement/issue template for bugs

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.md
+++ b/.github/ISSUE_TEMPLATE/bug.md
@@ -1,0 +1,15 @@
+---
+name: WGS Issue Template for Bugs
+about: Need to make an issue for a bug? Use this.
+---
+
+# Module/Page
+<!-- Module [> Sub-module] > Page -->
+
+# Current behaviour 😓
+<!-- [As 'role', ] when 'this', [and 'this'] … then 'that', [and 'that'] … -->
+
+# Expected behaviour 😀
+<!-- The 'As… When…' part of the sentence below should be the same between current and expected behaviour. -->
+<!-- Only the 'Then…' part should differ. -->
+<!-- [As 'role', ] when 'this', [and 'this'] … then 'that', [and 'that'] … -->

--- a/.github/ISSUE_TEMPLATE/default.md
+++ b/.github/ISSUE_TEMPLATE/default.md
@@ -1,6 +1,6 @@
 ---
-name: WGS Issue Template
-about: Need to make an issue? Use this.
+name: WGS Issue Template for Features/Improvements
+about: Need to make an issue for a feature or an improvement? Use this.
 ---
 
 <!-- The Title above should describe clearly and concisely the "what" -->


### PR DESCRIPTION
# Description
## Issue
closes #1

## What
Adding a template for bug issues. 

## How
Added a new markdown template file `bug.md` in the `.github/ISSUE_TEMPLATE folder`.

## Related PRs
N/A.

# Testing
- [ ] Unit Tests cover the change
- [ ] Smoke Tests cover the change

Neither Unit or Smoke tests are relevant/practicable is this case.

## Steps to Test or Reproduce
When I click on the 'New Issue' button in any repository, then I can choose between two templates:
- WGS Issue Template for Features/Improvements,
- WGS Issue Template for Bugs.

When I click on the 'Get Started' button of a template, then the issue description should be autocompleted with the template I selected.

# Ops
## Deploy
- [x] This is a standard deployment  

## Migrations
No
