### PR TITLE
Pin node version used everywhere to 14

### DIFF
--- a/.github/workflows/docker_deployer.yml
+++ b/.github/workflows/docker_deployer.yml
@@ -38,6 +38,9 @@ jobs:
           token: ${{ secrets.helper_token}}
           path: helper
           fetch-depth: 1
+      - uses: actions/setup-node@v2
+        with:
+          node-version: '14'
       - name: Login to AWS ECR
         uses: docker/login-action@v1
         with:

--- a/.github/workflows/pr_checker.yml
+++ b/.github/workflows/pr_checker.yml
@@ -26,5 +26,8 @@ jobs:
           token: ${{ secrets.helper_token }}
           path: helper
           fetch-depth: 1
+      - uses: actions/setup-node@v2
+        with:
+          node-version: '14'
       - name: Check
         uses: ./helper/.github/actions/check

--- a/.github/workflows/python_docker_build.yml
+++ b/.github/workflows/python_docker_build.yml
@@ -70,7 +70,7 @@ jobs:
           password: ${{ secrets.aws_key }}
       - name: Install Bender
         run: |
-          pip install --extra-index-url https://pypi.fury.io/Pfii9sZDGkGXEhXEmStx/webgeoservices/ bender==0.3.0
+          pip install --extra-index-url https://pypi.fury.io/Pfii9sZDGkGXEhXEmStx/webgeoservices/ bender==0.4.4
       - name: Install Required Packages
         if: ${{ inputs.install }} != ''
         run: |

--- a/.github/workflows/python_docker_build.yml
+++ b/.github/workflows/python_docker_build.yml
@@ -59,6 +59,9 @@ jobs:
           token: ${{ secrets.helper_token }}
           path: helper
           fetch-depth: 1
+      - uses: actions/setup-node@v2
+        with:
+          node-version: '14'
       - name: Login to AWS ECR
         uses: docker/login-action@v1
         with:

--- a/.github/workflows/smoke_test.yml
+++ b/.github/workflows/smoke_test.yml
@@ -49,6 +49,9 @@ jobs:
           token: ${{ secrets.helper_token }}
           path: helper
           fetch-depth: 1
+      - uses: actions/setup-node@v2
+        with:
+          node-version: '14'
       - name: Smoke Test
         uses: ./helper/.github/actions/run_smoke_tests
         with:


### PR DESCRIPTION
<!-- The Title above should provide a general summary of the PR -->
<!-- Any PR which has missing info is not ready to be reviewed -->
# Description
## Issue
<!-- Use `closes #1` with the number of the issue to find the issue -->
We are seeing some funny behaviour in some CI/CD runs
## What
<!-- What did you do? -->
I think this is due to miss matched node versions so I pinned the node version

## How
<!-- How did you do it? (Technically) -->
There is a Github Action step which can do this

# Ops
## Deploy
- [x] This is a standard deployment  
_If this box is not ticked please explain why and detail the steps to deploy._

## Migrations
<!-- Choose one -->
No
