### PR TITLE
Add build workflow with SonarCloud step

### DIFF
--- a/.github/workflows/sonar_python_bender_build.yml
+++ b/.github/workflows/sonar_python_bender_build.yml
@@ -14,6 +14,8 @@ on:
     secrets:
       helper_token:
         required: true
+      sonar_token:
+        required: true
       cache_aws_key_id:
         required: true
       cache_aws_key:
@@ -92,7 +94,7 @@ jobs:
       - name: SonarCloud Scan
         uses: SonarSource/sonarcloud-github-action@master
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN}}
+          GITHUB_TOKEN: ${{ secrets.helper_token }}
+          SONAR_TOKEN: ${{ secrets.sonar_token}}
       - name: Publish
         uses: ./helper/.github/actions/publish

--- a/.github/workflows/sonar_python_bender_build.yml
+++ b/.github/workflows/sonar_python_bender_build.yml
@@ -1,0 +1,98 @@
+name: Build - Python Docker based Service and run Sonar Checks.
+
+on:
+  workflow_call:
+    inputs:
+      envs:
+        default: ''
+        required: false
+        type: string
+      install:
+        default: ''
+        required: false
+        type: string
+    secrets:
+      helper_token:
+        required: true
+      cache_aws_key_id:
+        required: true
+      cache_aws_key:
+        required: true
+      aws_key_id:
+        required: true
+      aws_key:
+        required: true
+      aws_account:
+        required: true
+      slack_token:
+        required: true
+      maxmind:
+        required: false
+
+jobs:
+  test_actions:
+    runs-on: ubuntu-20.04
+    name: Build, Test, Sonar, Publish
+    env:
+      is_reco: ${{ secrets.maxmind }}
+      TERM: xterm-256color
+      FORCE_COLOR: 2
+      DOCKER_BUILDKIT: 1
+    steps:
+      - name: Set Env Vars
+        run: |
+          IFS=', ' read -r -a array <<< "${{ inputs.envs }}"
+          for str in "${array[@]}"; do
+            echo "${str}" >> $GITHUB_ENV
+          done
+        shell: bash
+      - name: Getting Build-Helper Tag
+        run: |
+          echo "HELPER_VERSION=$(git ls-remote --tags https://${{secrets.helper_token}}@github.com/WebGeoServices/build-helper.git | awk '{print $2}' | grep 'refs/tags/v4.*' | sort -nr | head -n 1)" >> $GITHUB_ENV
+      - uses: actions/checkout@v2
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          fetch-depth: 0
+      - uses: actions/checkout@v2
+        with:
+          repository: WebGeoServices/build-helper
+          ref: ${{ env.HELPER_VERSION }}
+          token: ${{ secrets.helper_token }}
+          path: helper
+          fetch-depth: 1
+      - name: Login to AWS ECR
+        uses: docker/login-action@v1
+        with:
+          registry: ${{ secrets.aws_account }}.dkr.ecr.us-east-1.amazonaws.com
+          username: ${{ secrets.aws_key_id }}
+          password: ${{ secrets.aws_key }}
+      - name: Install Bender
+        run: |
+          pip install --extra-index-url https://pypi.fury.io/Pfii9sZDGkGXEhXEmStx/webgeoservices/ "bender==0.4.*"
+      - name: Install Required Packages
+        if: ${{ inputs.install }} != ''
+        run: |
+          sudo apt install --no-install-recommends --yes ${{ inputs.install }}
+      - name: Download GeoIP (maxmind) DB (for woosmapreco)
+        if: ${{ env.is_reco }}
+        run: |
+          ./download_geoip_database.sh
+        env:
+          MAXMIND: ${{ secrets.maxmind }}
+      - name: Bender Build
+        uses: ./helper/.github/actions/builder
+      - name: Remove GeoIP (maxmind) DB (for woosmapreco)
+        if: ${{ env.is_reco }}
+        run: rm GeoIP2-City.mmdb
+      - name: Bender Test
+        uses: ./helper/.github/actions/run_tests
+        with:
+          cache_aws_key_id: ${{ secrets.cache_aws_key_id }}
+          cache_aws_key: ${{ secrets.cache_aws_key }}
+      - name: SonarCloud Scan
+        uses: SonarSource/sonarcloud-github-action@master
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN}}
+      - name: Publish
+        uses: ./helper/.github/actions/publish


### PR DESCRIPTION
<!-- The Title above should provide a general summary of the PR -->
<!-- Any PR which has missing info is not ready to be reviewed -->
# Description
## Issue
<!-- Use `closes #1` with the number of the issue to find the issue -->
We need a shared workflow which has a SonarCloud step instead of a Lint step
## What
<!-- What did you do? -->
Added new workflow `sonar_python_bender_build.yml`
## How
<!-- How did you do it? (Technically) -->
It requires a SONAR_TOKEN to be passed to it and runs the sonar step after the tests to collect the coverage report.

## Related PRs
<!-- List of related PRs against other branches/repos -->
<!-- - [ ] #1 -->
- [ ] https://github.com/WebGeoServices/maps/pull/106

# Testing
- [ ] Unit Tests cover the change
- [ ] Smoke Tests cover the change  
_If one of the above boxes is not ticked please explain why._
N/A

## Steps to Test or Reproduce
- Run the build on the related PR

# Ops
## Deploy
- [x] This is a standard deployment  
_If this box is not ticked please explain why and detail the steps to deploy._

## Migrations
<!-- Choose one -->
No
