### PR TITLE
Sonar caching and master checks

### DIFF
--- a/.github/workflows/sonar_docker_deployer.yml
+++ b/.github/workflows/sonar_docker_deployer.yml
@@ -1,0 +1,71 @@
+name: Sonar scan & Deploy on merged PR
+
+on:
+  workflow_call:
+    secrets:
+      helper_token:
+        required: true
+      sonar_token:
+        required: true
+      cache_aws_key_id:
+        required: true
+      cache_aws_key:
+        required: true
+      aws_key_id:
+        required: true
+      aws_key:
+        required: true
+      aws_account:
+        required: true
+      slack_token:
+        required: true
+
+jobs:
+  deploy_actions:
+    runs-on: ubuntu-20.04
+    name: Deploy Docker
+    env:
+      TERM: xterm-256color
+      FORCE_COLOR: 2
+      DOCKER_BUILDKIT: 1
+    steps:
+      - name: Getting Build-Helper Tag
+        run: |
+          echo "HELPER_VERSION=$(git ls-remote --tags https://${{secrets.helper_token}}@github.com/WebGeoServices/build-helper.git | awk '{print $2}' | grep 'refs/tags/v4.*' | sort -nr | head -n 1)" >> $GITHUB_ENV
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - uses: actions/checkout@v2
+        with:
+          repository: WebGeoServices/build-helper
+          ref: ${{ env.HELPER_VERSION }}
+          token: ${{ secrets.helper_token}}
+          path: helper
+          fetch-depth: 1
+      - name: Login to AWS ECR
+        uses: docker/login-action@v1
+        with:
+          registry:  ${{ secrets.aws_account }}.dkr.ecr.us-east-1.amazonaws.com
+          username: ${{ secrets.aws_key_id }}
+          password: ${{ secrets.aws_key }}
+      - name: Release
+        uses: ./helper/.github/actions/release
+        with:
+          slack_token: ${{ secrets.slack_token }}
+          cache_aws_key_id: ${{ secrets.cache_aws_key_id }}
+          cache_aws_key: ${{ secrets.cache_aws_key }}
+      - name: Deploy Develop
+        uses: ./helper/.github/actions/deploy
+      - name: Restore code coverage cache
+        uses: ./helper/.github/actions/cache
+        with:
+          restore: 'true'
+          path: './coverage/coverage.xml'
+          key: 'coverage'
+          cache_aws_key_id: ${{ secrets.cache_aws_key_id }}
+          cache_aws_key: ${{ secrets.cache_aws_key }}
+      - name: SonarCloud Scan
+        uses: SonarSource/sonarcloud-github-action@master
+        env:
+          GITHUB_TOKEN: ${{ secrets.helper_token }}
+          SONAR_TOKEN: ${{ secrets.sonar_token}}

--- a/.github/workflows/sonar_python_bender_build.yml
+++ b/.github/workflows/sonar_python_bender_build.yml
@@ -70,7 +70,7 @@ jobs:
           password: ${{ secrets.aws_key }}
       - name: Install Bender
         run: |
-          pip install --extra-index-url https://pypi.fury.io/Pfii9sZDGkGXEhXEmStx/webgeoservices/ "bender==0.4.*"
+          pip install --extra-index-url https://pypi.fury.io/Pfii9sZDGkGXEhXEmStx/webgeoservices/ "bender==0.5.*"
       - name: Install Required Packages
         if: ${{ inputs.install }} != ''
         run: |
@@ -88,7 +88,24 @@ jobs:
         run: rm GeoIP2-City.mmdb
       - name: Bender Test
         uses: ./helper/.github/actions/run_tests
+      - name: Cache code coverage
+        uses: ./helper/.github/actions/cache
         with:
+          path: './coverage/coverage.xml'
+          key: 'coverage'
+          cache_aws_key_id: ${{ secrets.cache_aws_key_id }}
+          cache_aws_key: ${{ secrets.cache_aws_key }}
+      - name: REMOVE TESTING
+        run: |
+          ls
+          rm -r ./coverage
+          ls
+      - name: REMOVE TESTING Restore code coverage cache
+        uses: ./helper/.github/actions/cache
+        with:
+          restore: 'true'
+          path: './coverage/coverage.xml'
+          key: 'coverage'
           cache_aws_key_id: ${{ secrets.cache_aws_key_id }}
           cache_aws_key: ${{ secrets.cache_aws_key }}
       - name: SonarCloud Scan

--- a/.github/workflows/sonar_python_bender_build.yml
+++ b/.github/workflows/sonar_python_bender_build.yml
@@ -95,19 +95,6 @@ jobs:
           key: 'coverage'
           cache_aws_key_id: ${{ secrets.cache_aws_key_id }}
           cache_aws_key: ${{ secrets.cache_aws_key }}
-      - name: REMOVE TESTING
-        run: |
-          ls
-          rm -r ./coverage
-          ls
-      - name: REMOVE TESTING Restore code coverage cache
-        uses: ./helper/.github/actions/cache
-        with:
-          restore: 'true'
-          path: './coverage/coverage.xml'
-          key: 'coverage'
-          cache_aws_key_id: ${{ secrets.cache_aws_key_id }}
-          cache_aws_key: ${{ secrets.cache_aws_key }}
       - name: SonarCloud Scan
         uses: SonarSource/sonarcloud-github-action@master
         env:


### PR DESCRIPTION
<!-- The Title above should provide a general summary of the PR -->
<!-- Any PR which has missing info is not ready to be reviewed -->
# Description
## Issue
<!-- Use `closes #1` with the number of the issue to find the issue -->
Sonar needs is scans to run on master after PRs are merged
## What
<!-- What did you do? -->
Added a step in the workflows for Sonar to check the code.
Also added a cache action so we can store code coverage and not need to rerun tests on master.

## How
<!-- How did you do it? (Technically) -->
After the deploy sonar scan is ran.
Use S3 to store coverage ran in PR and restore just before the sonarscan step.

## Related PRs
<!-- List of related PRs against other branches/repos -->
<!-- - [ ] #1 -->
- [ ] https://github.com/WebGeoServices/build-helper/pull/57
# Testing
- [x] Unit Tests cover the change
- [x] Smoke Tests cover the change  
_If one of the above boxes is not ticked please explain why._

## Steps to Test or Reproduce
- I will run a PR build of maps to check

# Ops
## Deploy
- [x] This is a standard deployment  
_If this box is not ticked please explain why and detail the steps to deploy._

## Migrations
<!-- Choose one -->
No
