### PR TITLE
Allow dependabot to run build steps.

### DIFF
--- a/.github/workflows/python_docker_build.yml
+++ b/.github/workflows/python_docker_build.yml
@@ -31,6 +31,9 @@ on:
 
 jobs:
   test_actions:
+    if: |
+      (github.event_name == 'pull_request' && github.actor != 'dependabot[bot]') ||
+      (github.event_name == 'pull_request_target' && github.actor == 'dependabot[bot]')
     runs-on: ubuntu-20.04
     name: Lint, Build, Test, Publish
     env:

--- a/.github/workflows/sonar_python_bender_build.yml
+++ b/.github/workflows/sonar_python_bender_build.yml
@@ -33,6 +33,9 @@ on:
 
 jobs:
   test_actions:
+    if: |
+      (github.event_name == 'pull_request' && github.actor == 'dependabot[bot]') ||
+      (github.event_name == 'pull_request_target' && github.actor == 'dependabot[bot]')
     runs-on: ubuntu-20.04
     name: Build, Test, Sonar, Publish
     env:


### PR DESCRIPTION
<!-- The Title above should provide a general summary of the PR -->
<!-- Any PR which has missing info is not ready to be reviewed -->
# Description
## Issue
<!-- Use `closes #1` with the number of the issue to find the issue -->
Currently we can either have working DBot builds or have pr builds run on the current version of the workflow in the PR, not both.
## What
<!-- What did you do? -->
Allowed it so we can have both by making both valid and checking to ensure only one is built
## How
<!-- How did you do it? (Technically) -->
Add an if on jobs so normal builds are ran on PRs and DBot builds are run on PR_target (master)

## Related PRs
<!-- List of related PRs against other branches/repos -->
<!-- - [ ] #1 -->

# Testing
- [ ] Unit Tests cover the change
- [ ] Smoke Tests cover the change  
_If one of the above boxes is not ticked please explain why._
Tested in PR on maps

## Steps to Test or Reproduce
- `./run_test.sh`

# Ops
## Deploy
- [x] This is a standard deployment  
_If this box is not ticked please explain why and detail the steps to deploy._

## Migrations
<!-- Choose one -->
No
